### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.7-stretch
+
+ENV GO_VERSION 1.12.9
+ENV GO_TAR go${GO_VERSION}.linux-amd64.tar.gz
+ENV GOROOT /usr/local/go
+ENV GOPATH /root/go
+ENV PATH ${GOPATH}/bin:${GOROOT}/bin:${PATH}
+
+# rmapi
+RUN wget https://dl.google.com/go/${GO_TAR} \
+    && tar -xf ${GO_TAR} \
+    && mv go ${GOROOT} \
+    && rm ${GO_TAR} \
+    && go get -u github.com/juruen/rmapi
+
+# pdftk & pdfcrop
+RUN apt-get update \
+    && apt-get install -y \
+        pdftk \
+        texlive-extra-utils  # contains pdfcrop
+
+RUN pip install \
+    bs4 \
+    requests \
+    PyPDF2 \
+    titlecase \
+    pdfplumber \
+    unidecode
+
+COPY arxiv2remarkable.py ./
+
+ENTRYPOINT ["python", "arxiv2remarkable.py"]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,43 @@ you can use ``pip`` with the following command:
 pip install --user bs4 requests PyPDF2 titlecase pdfplumber unidecode
 ```
 
+## Docker
+
+You can also use our Dockerfile to avoid installing dependencies on your machine. You will need `git` and `docker` installed.
+
+First clone this repository with `git clone` and `cd` inside of it, then build the container:
+
+```bash
+docker build -t arxiv2remarkable .
+```
+
+### Authorization
+
+If you already have a `~/.rmapi` file, you can skip this section. Otherwise we'll use `rmapi` to create it.
+
+```bash
+touch ${HOME}/.rmapi
+docker run --rm --it -v "${HOME}/.rmapi:/root/.rmapi:rw" --entrypoint=rmapi arxiv2remarkable version
+```
+
+which should end with output like
+
+```bash
+ReMarkable Cloud API Shell
+rmapi version: 0.0.5
+```
+
+### Usage
+
+Use the container by replacing `python arxiv2remarkable.py` with `docker run --rm -v "${HOME}/.rmapi:/root/.rmapi:rw" arxiv2remarkable`, e.g.
+```
+# print help and exit
+docker run --rm -v "${HOME}/.rmapi:/root/.rmapi:rw" arxiv2remarkable --help
+
+# equivalent to above usage via `python`
+docker run --rm -v "${HOME}/.rmapi:/root/.rmapi:rw" arxiv2remarkable -v https://arxiv.org/abs/1811.11242
+```
+
 # Notes
 
 License: MIT


### PR DESCRIPTION
Hi @GjjvdBurg, I noticed each time I installed this on a new machine it was a lot of work to install all the dependencies, so I packaged it up into a `Dockerfile` that seems to work equivalently to the `python arxiv2remarkable.py` usage. I also added to the README to explain how to use it, including getting the `~/.rmapi` file with it.

I know this is an unsolicited PR, so if you'd rather not add this, please don't hesitate to close it. I'm happy to make any changes you like.

If you think this is useful, we could also go further and
- put it on Docker Hub so users don't have to build it locally
- use CI/CD to keep that up to date
- add daemon-style usage instructions (like https://github.com/jessfraz/morningpaper2remarkable#running-with-docker)
etc.